### PR TITLE
avoiding aws-config conflicts with other plugins by reusing config node of node-red-node-aws plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A function block where you can write your own code to execute aws-sdk nodejs lib
 [![npm version](https://badge.fury.io/js/node-red-contrib-aws-sdk.svg)](https://badge.fury.io/js/node-red-contrib-aws-sdk)
 
 **Example of using aws-sdk inside this function block:**
-	
+
 ```javascript
 // Create a bucket using bound parameters and put something in it.
 // Make sure to change the bucket name from "myBucket" to something unique.

--- a/aws-sdk.html
+++ b/aws-sdk.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="aws-config">
+<script type="text/x-red" data-template-name="aws-config-extended">
 	<div class="form-row">
 		<ul style="background: #fff; min-width: 600px; margin-bottom: 20px;" id="node-config-aws-config-tabs"></ul>
 	</div>
@@ -24,14 +24,10 @@ limitations under the License.
 				<label for="node-config-input-name"><i class="fa fa-globe"></i> <span>Name</span></label>
 					<input class="input-append-left" type="text" id="node-config-input-name" placeholder="Enter a configuration name" style="width: 40%;" >
 			</div>
-			<div class="form-row node-input-access-key">
-				<label for="node-config-input-access-key"><i class="fa fa-link"></i> <span>Access Key</span></label>
-					<input class="input-append-left" type="text" id="node-config-input-access-key" placeholder="AWS Access Key" style="width: 40%;" >
-			</div>
-			<div class="form-row node-input-secret-key">
-				<label for="node-config-input-secret-key"><i class="fa fa-edit"></i> <span>Secret Key</span></label>
-				<input type="number" id="node-config-input-secret-key" placeholder="AWS Secret Key" style="width: 40%;">
-			</div>
+			<div class="form-row">
+        <label for="node-input-aws"><i class="fa fa-user"></i> AWS</label>
+        <input type="text" id="node-config-input-aws">
+      </div>
 			<div class="form-row">
 		        <label for="node-config-input-region"><i class="fa fa-empire"></i> <span>Region</span></label>
 		        <select id="node-config-input-region" style="width:225px !important">
@@ -42,13 +38,9 @@ limitations under the License.
 		            <option value="eu-central-1">EU (Frankfurt)</option>
 		            <option value="ap-southeast-1">Asia Pacific (Singapore)</option>
 		            <option value="ap-northeast-1">Asia Pacific (Tokyo)</option>
-		            <option value="ap-southeast-2">Asia Pacific (Sydney)</option>		            
+		            <option value="ap-southeast-2">Asia Pacific (Sydney)</option>
 		        </select>
 		    </div>
-		    <div class="form-row">
-                <input type="checkbox" id="node-config-input-iamrole" style="display: inline-block; width: auto; vertical-align: top;">
-                <label for="node-config-input-iamrole" style="width: auto;" >Use Base IAM Role Setting</label>
-            </div>
 		</div>
 		<div id="aws-config-tab-about" style="display:none">
 			<div class="form-row node-label-author">
@@ -64,23 +56,18 @@ limitations under the License.
 </script>
 
 <script type="text/javascript">
-	RED.nodes.registerType('aws-config', {
+	RED.nodes.registerType('aws-config-extended', {
 		category : 'config',
 		defaults : {
 			name : {
 				value : ""
 			},
-			accesskey : {
-				value : ""
-			},
-			secretkey : {
-				value : ""
+			aws: {
+				type:"aws-config",
+				required:true
 			},
 			region : {
 				value : ""
-			},
-			iamrole: { 
-				value: true
 			}
 		},
 		label : function() {
@@ -106,7 +93,7 @@ limitations under the License.
 				tabs.resize();
 			}, 0);
 		}
-	}); 
+	});
 </script>
 
 <script type="text/x-red" data-template-name="aws sdk">
@@ -142,9 +129,9 @@ limitations under the License.
 		&nbsp;&nbsp;var params = {Bucket: 'myBucket', Key: 'myKey', Body: 'Hello!'};<br/>
 		&nbsp;&nbsp;s3.putObject(params, function(err, data) {
 		&nbsp;&nbsp;&nbsp;&nbsp;msg.payload = data;
-		&nbsp;&nbsp;&nbsp;&nbsp;callback(msg);	
+		&nbsp;&nbsp;&nbsp;&nbsp;callback(msg);
 		&nbsp;&nbsp;});<br/>
-		});	
+		});
 	</code></p>
 </script>
 
@@ -170,7 +157,7 @@ limitations under the License.
 				}
 			},
 			config : {
-				type : "aws-config",
+				type : "aws-config-extended",
 				required : true
 			}
 		},
@@ -242,5 +229,5 @@ limitations under the License.
 			$("#node-input-func").val(this.editor.getValue());
 			delete this.editor;
 		}
-	}); 
+	});
 </script>

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
 	"name": "node-red-contrib-aws-sdk",
 	"version": "0.1.4",
 	"description": "The aws sdk wrapper node which allows you to execute aws functions in javascript block.",
-	"dependencies": {		
-		"aws-sdk" : ">=2.4.2"
+	"dependencies": {
+		"aws-sdk" : ">=2.4.2",
+		"node-red-node-aws": "0.1.1"
 	},
 	"license": "Apache-2.0",
 	"keywords": ["node-red", "aws", "sdk"],


### PR DESCRIPTION
reworking the access key and secret key configuration by reusing the aws-config node of the node-red-node-aws plugin. Renamed the config node defined in this plugin to 'aws-config-extended' to avoid conflicts with other aws plugins which also define an 'aws-config' data-template-name
